### PR TITLE
June patch release - Workaround for missing tags

### DIFF
--- a/bundles/cilium.v1.11.18/manifests/cilium.clusterserviceversion.yaml
+++ b/bundles/cilium.v1.11.18/manifests/cilium.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:04833b601fa130512450afa45c4fe484fee1293634f34c7ddc231bd193c74017
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:61186a63e62e67de964f95cf22c4faf89468120f-v1.11.18
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:f73310b8109ed47ff4e9ba4ce599843795e269bb3b924eff80a5df775411fc16
                     name: operator
                     ports:
                       - containerPort: 9443

--- a/bundles/cilium.v1.12.11/manifests/cilium.clusterserviceversion.yaml
+++ b/bundles/cilium.v1.12.11/manifests/cilium.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:7b890a7eba1a267c233a848ad0c684b36f9d6ef4-v1.12.11
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:16669a9908499b66d08d6a5d486df58af6c4df8db3c83ffff714d239f46837af
                     name: operator
                     ports:
                       - containerPort: 9443

--- a/bundles/cilium.v1.13.4/manifests/cilium.clusterserviceversion.yaml
+++ b/bundles/cilium.v1.13.4/manifests/cilium.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:b1a7395551c434eefb5abc39673f6c2e0c9efb91-v1.13.4
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:5c5a3b53389ba6e2a9d5b649ab0dbd1d6abd81cea9100fad55ea5916ec08f023
                     name: operator
                     ports:
                       - containerPort: 9443

--- a/manifests/cilium.v1.11.18/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/manifests/cilium.v1.11.18/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
             - name: RELATED_IMAGE_CLUSTERMESH_ETCD
               value: quay.io/coreos/etcd@sha256:04833b601fa130512450afa45c4fe484fee1293634f34c7ddc231bd193c74017
-          image: registry.connect.redhat.com/isovalent/cilium-olm:61186a63e62e67de964f95cf22c4faf89468120f-v1.11.18
+          image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:f73310b8109ed47ff4e9ba4ce599843795e269bb3b924eff80a5df775411fc16
           name: operator
           ports:
             - containerPort: 9443

--- a/manifests/cilium.v1.11.18/cluster-network-06-cilium-00014-cilium.v1.11.18-x2b5131b-clusterserviceversion.yaml
+++ b/manifests/cilium.v1.11.18/cluster-network-06-cilium-00014-cilium.v1.11.18-x2b5131b-clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:04833b601fa130512450afa45c4fe484fee1293634f34c7ddc231bd193c74017
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:61186a63e62e67de964f95cf22c4faf89468120f-v1.11.18
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:f73310b8109ed47ff4e9ba4ce599843795e269bb3b924eff80a5df775411fc16
                     name: operator
                     ports:
                       - containerPort: 9443

--- a/manifests/cilium.v1.12.11/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/manifests/cilium.v1.12.11/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
             - name: RELATED_IMAGE_CLUSTERMESH_ETCD
               value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-          image: registry.connect.redhat.com/isovalent/cilium-olm:7b890a7eba1a267c233a848ad0c684b36f9d6ef4-v1.12.11
+          image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:16669a9908499b66d08d6a5d486df58af6c4df8db3c83ffff714d239f46837af
           name: operator
           ports:
             - containerPort: 9443

--- a/manifests/cilium.v1.12.11/cluster-network-06-cilium-00014-cilium.v1.12.11-xc8fb7eb-clusterserviceversion.yaml
+++ b/manifests/cilium.v1.12.11/cluster-network-06-cilium-00014-cilium.v1.12.11-xc8fb7eb-clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:7b890a7eba1a267c233a848ad0c684b36f9d6ef4-v1.12.11
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:16669a9908499b66d08d6a5d486df58af6c4df8db3c83ffff714d239f46837af
                     name: operator
                     ports:
                       - containerPort: 9443

--- a/manifests/cilium.v1.13.4/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
+++ b/manifests/cilium.v1.13.4/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
             - name: RELATED_IMAGE_CLUSTERMESH_ETCD
               value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-          image: registry.connect.redhat.com/isovalent/cilium-olm:b1a7395551c434eefb5abc39673f6c2e0c9efb91-v1.13.4
+          image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:5c5a3b53389ba6e2a9d5b649ab0dbd1d6abd81cea9100fad55ea5916ec08f023
           name: operator
           ports:
             - containerPort: 9443

--- a/manifests/cilium.v1.13.4/cluster-network-06-cilium-00014-cilium.v1.13.4-x129f2a7-clusterserviceversion.yaml
+++ b/manifests/cilium.v1.13.4/cluster-network-06-cilium-00014-cilium.v1.13.4-x129f2a7-clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                         value: quay.io/cilium/startup-script@sha256:a1454ca1f93b69ecd2c43482c8e13dc418ae15e28a46009f5934300a20afbdba
                       - name: RELATED_IMAGE_CLUSTERMESH_ETCD
                         value: quay.io/coreos/etcd@sha256:a67fb152d4c53223e96e818420c37f11d05c2d92cf62c05ca5604066c37295e9
-                    image: registry.connect.redhat.com/isovalent/cilium-olm:b1a7395551c434eefb5abc39673f6c2e0c9efb91-v1.13.4
+                    image: registry.connect.redhat.com/isovalent/cilium-olm@sha256:5c5a3b53389ba6e2a9d5b649ab0dbd1d6abd81cea9100fad55ea5916ec08f023
                     name: operator
                     ports:
                       - containerPort: 9443


### PR DESCRIPTION
```console
$ cd /tmp/cilium-olm
$ yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image = \"registry.connect.redhat.com/isovalent/cilium-olm@$IMAGE_SHA\"" bundles/cilium.v$RELEASE/manifests/cilium.clusterserviceversion.yaml
$ yq -i ".spec.template.spec.containers[0].image = \"registry.connect.redhat.com/isovalent/cilium-olm@$IMAGE_SHA\"" manifests/cilium.v$RELEASE/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
$ yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image = \"registry.connect.redhat.com/isovalent/cilium-olm@$IMAGE_SHA\"" manifests/cilium.v$RELEASE/cluster-network-06-cilium-00014-cilium.v$RELEASE-*-clusterserviceversion.yaml
$ git commit -sam "v${RELEASE} release: image tag workaround"
```

... Rince and repeat for each patch release.