### PR TITLE
publish: Make input version parameter handling more robust

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Define version to be built and tested'
+        description: 'Define version to be built and tested (example: "1.13.4")'
         required: true
 
 jobs:
@@ -16,7 +16,9 @@ jobs:
       - id: set
         name: Set OLM Tag
         run: |
-          olm_tag=$(yq .spec.install.spec.deployments[0].spec.template.spec.containers[0].image bundles/cilium.v${{ github.event.inputs.version }}/manifests/cilium.clusterserviceversion.yaml | cut -d ':' -f 2)
+          VERSION="${{ github.event.inputs.version }}"
+          set -o pipefail
+          olm_tag=$(yq .spec.install.spec.deployments[0].spec.template.spec.containers[0].image bundles/cilium.v${VERSION#v}/manifests/cilium.clusterserviceversion.yaml | cut -d ':' -f 2)
           echo "::set-output name=OLM_TAG::${olm_tag}"
   build-and-publish:
     if: needs.set-olm-tag.outputs.olm-tag != ''


### PR DESCRIPTION
Guess who passed `v1.13.4` instead of `1.13.4` to the `publish` workflow and was left scratching his head when looking for the missing images on RedHat's interface??

To make the workflow more robust with regards to its input parameter:

- Add an example to the parameter description.

- Accept passing a `v` prefix for the version number (e.g. `v1.13.4` instead of just `1.13.4`).

- Make sure we exit with an error if the parameter is not correct and one command fails in the pipeline (before this commit, piping into `cut` would make the command succeed even if the file is not found).

I'm not sure how to test the changes :thinking:.