### PR TITLE
feat: skip in-between versions when updating

### DIFF
--- a/config/operator/olm.cue
+++ b/config/operator/olm.cue
@@ -91,6 +91,7 @@ _csv_annotations: {
 	"alm-examples-metadata":                          json.Marshal(_alm_examples_metadata)
 	"alm-examples":                                   json.Marshal(_alm_examples)
 	"operators.openshift.io/infrastructure-features": "[\"disconnected\"]"
+	"olm.skipRange":                                  ">=\(parameters.ciliumMajorMinor).0 <\(parameters.ciliumVersion)+x\(parameters.configVersionSuffix)"
 }
 
 _logoString: """


### PR DESCRIPTION
Add a skipRange annotation that makes possible to skip in-between releases when updating within a minor version.