### PR TITLE
chore: replace nativeRoutingCIDR by ipv4NativeRoutingCIDR

### DIFF
--- a/ciliumconfig.conformance.v1.12.yaml
+++ b/ciliumconfig.conformance.v1.12.yaml
@@ -23,7 +23,7 @@ spec:
     operator:
       clusterPoolIPv4PodCIDR: "10.128.0.0/14"
       clusterPoolIPv4MaskSize: "23"
-  nativeRoutingCIDR: "10.128.0.0/14"
+  ipv4NativeRoutingCIDR: "10.128.0.0/14"
   endpointRoutes: {enabled: true}
   kubeProxyReplacement: "probe"
   clusterHealthPort: 9940

--- a/ciliumconfig.conformance.v1.13.yaml
+++ b/ciliumconfig.conformance.v1.13.yaml
@@ -23,7 +23,7 @@ spec:
     operator:
       clusterPoolIPv4PodCIDR: "10.128.0.0/14"
       clusterPoolIPv4MaskSize: "23"
-  nativeRoutingCIDR: "10.128.0.0/14"
+  ipv4NativeRoutingCIDR: "10.128.0.0/14"
   endpointRoutes: {enabled: true}
   clusterHealthPort: 9940
   tunnelPort: 4789

--- a/ciliumconfig.conformance.v1.14.yaml
+++ b/ciliumconfig.conformance.v1.14.yaml
@@ -24,7 +24,7 @@ spec:
       clusterPoolIPv4PodCIDRList:
         - "10.128.0.0/14"
       clusterPoolIPv4MaskSize: "23"
-  nativeRoutingCIDR: "10.128.0.0/14"
+  ipv4NativeRoutingCIDR: "10.128.0.0/14"
   endpointRoutes: {enabled: true}
   clusterHealthPort: 9940
   tunnelPort: 4789


### PR DESCRIPTION
`nativeRoutingCIDR` has been[ deprecated and removed since 1.12](https://github.com/isovalent/olm-for-cilium/blob/main/operator/cilium.v1.11.0/cilium/values.yaml#L1055-L1058). It is now replaced by `ipv4NativeRoutingCIDR` and `ipv6NativeRoutingCIDR`.
