### PR TITLE
#89 Fix permissions for 'leases' resource in 'coordination' API group

### DIFF
--- a/config/operator/rbac.cue
+++ b/config/operator/rbac.cue
@@ -151,6 +151,8 @@ _ciliumClusterRules: [
 			"create",
 			"get",
 			"update",
+			"list",
+			"delete",
 		]
 	},
 	{


### PR DESCRIPTION
Just changed the CUE file, not recreated the manifest itself, I guess that's done automatically.